### PR TITLE
[81]: Fix `open_editor` "broken" in case of insert mode 

### DIFF
--- a/bin/tempura/src/cmds/open_editor.rs
+++ b/bin/tempura/src/cmds/open_editor.rs
@@ -99,8 +99,11 @@ pub fn run<'a>(mut args: impl Iterator<Item = &'a str>) -> anyhow::Result<()> {
         .args([
             "-c",
             &format!(
+                // `wezterm cli send-text $'\e'` sends the "ESC" to WezTerm to exit from insert mode
+                // https://github.com/wez/wezterm/discussions/3945
                 r#"
-                    wezterm cli send-text --pane-id '{editor_pane_id}' '{open_file_cmd}' --no-paste && \
+                    wezterm cli send-text $'\e' --pane-id '{editor_pane_id}' --no-paste && \
+                        wezterm cli send-text '{open_file_cmd}' --pane-id '{editor_pane_id}' --no-paste && \
                         printf "\r" | wezterm cli send-text --pane-id '{editor_pane_id}' --no-paste && \
                         wezterm cli activate-pane --pane-id '{editor_pane_id}'
                 "#,


### PR DESCRIPTION
[![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://www.meetup.com/it-IT/Open-Source-Saturday-Milano/)